### PR TITLE
Support rich message objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Run the following command in the root directory of your Node-RED install:
 This node only writes to your Facebook page. To do that it needs a recipient id (which is normally the sender id from a message received) and an Access Token (something that you set up when you
 follow the facebook messenger developers quick start guide.  [Facebook Messenger Developers Quick Start Guide](https://developers.facebook.com/docs/messenger-platform/guides/quick-start))
 
-The message to send should be set in msg.payload
+The message to send should be set in msg.payload. If msg.payload is a string, the string will be sent as the message.
+If msg.payload is an object, the object will be sent unaltered.
 
 The node needs an ID to send the return message. As the recipient for the
 response is normally the sender of the original message, msg.facebookevent

--- a/nodes/v1.html
+++ b/nodes/v1.html
@@ -35,7 +35,10 @@
     <p><b>Usage</b></p>
     <p>This node should be provided in input : </p>
     <ul>
-      <li><code>msg.payload</code> : the message to send. Format: String </li>
+      <li><code>msg.payload</code> : the message to send. Format: String or Object. 
+        If msg.payload is an object, the whole object will be sent as the message. 
+        You can use this to add, eg, custom quick replies to your messages.
+      </li>
       <li><code>msg.facebookevent</code> : a facebook event, which is normally,
       received on an incoming message. Refer to the
       <a href="https://github.com/ibm-early-programs/node-red-contrib-facebook-messenger-writer"

--- a/nodes/v1.js
+++ b/nodes/v1.js
@@ -21,8 +21,8 @@ module.exports = function (RED) {
     if (!msg.payload) {
       return 'Missing property: msg.payload';
     }
-    if ('string' !== typeof(msg.payload)) {
-      return 'submitted msg.payload is not text';
+    if ('string' !== typeof(msg.payload) && !msg.payload.text) {
+      return 'msg.payload must be a string or contain a "text" key';
     }
     if (!msg.facebookevent) {
       return  'Missing property: msg.facebookevent';
@@ -40,11 +40,22 @@ module.exports = function (RED) {
     return '';
   }
 
-  function sendReplyMessage(node, token, to, text) {
+  function sendReplyMessage(node, token, to, msg_obj) {
+    var our_msg;
+
+    if ('string' == typeof(msg_obj)) {
+      // If the message is just a string, format it appropriately
+      our_msg = {text: msg_obj};
+    } else {
+      // Otherwise, pass it on unmaligned
+      our_msg = msg_obj;
+    }
+    
     var messageData = {
-      recipient: {id: to},
-      message: {text: text}
-    };
+        recipient: {id: to},
+        message: our_msg
+      };
+  
 
     request({
       uri: 'https://graph.facebook.com/v2.6/me/messages',


### PR DESCRIPTION
Hi - this a quick patch I wrote so that I could pass a whole message object to this node, rather than just text. This allows for setting of the 'quick_replies' attribute, for example, which can be quite useful. 

The original behaviour of accepting text is preserved, so this should be a non-breaking change.
